### PR TITLE
feat: change debug log colour to cyan for readability

### DIFF
--- a/src/LoggerFactory.ts
+++ b/src/LoggerFactory.ts
@@ -42,7 +42,7 @@ export class LoggerFactory implements LoggerFactoryInterface {
       },
       transports,
       format: winston.format.combine(
-        winston.format.colorize({ all: true }),
+        winston.format.colorize({ all: true, colors: { debug: "cyan" } }),
         winston.format.splat(),
         winston.format.timestamp(),
         winston.format.printf(({ timestamp, level, message, name }) =>


### PR DESCRIPTION
Blue text can be hard to read in some terminals, instead we can use cyan for debug logs as it doesn't clash with existing log level colours